### PR TITLE
Add `cwd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # Zapusk
 
-![Zapusk ScreenShot](.imgs/zapusk.png)
+![Zapusk Screenshot](.imgs/zapusk.png)
 
-Zapusk is a job runner for desktop environments. It helps you manage background tasks with features like pre-configured job execution, background shell commands, scheduling with cron-like syntax, log tailing, and notifications. It also provides detailed JSON output for easy data manipulation and analysis.
+Zapusk is a versatile job runner designed for desktop environments. It simplifies the process of managing background tasks by providing robust features such as pre-configured job execution, background shell command execution, cron-like scheduling, log tailing, and notifications. Zapusk's detailed JSON output also enables powerful data manipulation and analysis when paired with tools like jq.
 
+## Table of Contents
+
+- [Key Features](#key-features)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Basic Commands](#basic-commands)
+  - [Advanced Usage](#advanced-usage)
+- [Configuration](#configuration)
+- [Examples](#examples)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Key Features
 
@@ -15,6 +26,7 @@ Zapusk is a job runner for desktop environments. It helps you manage background 
 - **Job Groups:** Share settings like callbacks and parallelism between jobs.
 - **Colored JSON Output:** Easily readable JSON output.
 - **Waybar Integration:** Display job statuses and notifications on Waybar.
+- **Custom Working Directory:** Run scripts and callbacks in a specified working directory.
 
 ## Installation
 
@@ -26,8 +38,9 @@ pip install zapusk
 
 ## Usage
 
-Zapusk requires `zapusk-server` to be started. Zapusk offers a command-line interface for managing and executing jobs.
-Here's a quick reference:
+Zapusk requires `zapusk-server` to be started. Zapusk offers a command-line interface for managing and executing jobs. Here's a quick reference:
+
+### Basic Commands
 
 ```sh
 Usage:
@@ -51,34 +64,36 @@ Options:
   -n --name=<name>              Name for a command.
   -g --group=<group>            Job group to run the command in.
   -t --tail                     Tail logfile immediately.
-
-Examples:
-
-    # Run npm install in the background
-    zapusk exec "npm i"
-
-    # Run pytest and tail its log
-    zapusk exec "pytest -v" -t
-
-    # Schedule a command to run every minute
-    zapusk exec "ping -c4 google.com" --schedule "*/1 * * * *"
-
-    # Run a job defined in ~/.config/zapusk/config.yaml
-    zapusk run youtube_dl
-
-    # Cancel a job by its ID
-    zapusk cancel 42
-
-    # See logs for a job by its ID
-    zapusk tail 42
 ```
 
-## Example Configuration
+### Examples
 
-Here is an example configuration file for Zapusk. It defines job groups and individual jobs, specifying commands, schedules, and notifications.
+```sh
+# Run npm install in the background
+zapusk exec "npm i"
+
+# Run pytest and tail its log
+zapusk exec "pytest -v" -t
+
+# Schedule a command to run every minute
+zapusk exec "ping -c4 google.com" --schedule "*/1 * * * *"
+
+# Run a job defined in ~/.config/zapusk/config.yaml
+zapusk run youtube_dl
+
+# Cancel a job by its ID
+zapusk cancel 42
+
+# See logs for a job by its ID
+zapusk tail 42
+```
+
+## Configuration
+
+Here is an example configuration file for Zapusk. It defines job groups and individual jobs, specifying commands, schedules, notifications, and working directories.
 
 ```yaml
-# Port server starts on and client call to
+# The port the server starts on and the client connects to
 port: 9876
 
 # Enable colored JSON output
@@ -103,6 +118,7 @@ jobs:
     id: unsplash
     args_command: "zenity --entry --text 'Collection ID'"
     command: ~/.bin/jobs/unsplash_dl.sh
+    cwd: /path/to/working/directory
 
   - name: Sleep
     id: sleep
@@ -132,6 +148,7 @@ jobs:
     id: unsplash
     args_command: "zenity --entry --text 'Collection ID'"
     command: ~/.bin/jobs/unsplash_wallpaper_collection_download.sh
+    cwd: /path/to/working/directory
     on_finish: notify-send -a "Zapusk" "Wallpapers downloaded" --icon kitty
     on_fail: notify-send -a "Zapusk" "Wallpaper download failed" --icon kitty
 ```
@@ -210,11 +227,12 @@ jobs:
     id: sleep
     group: sleep
     command: ~/.bin/jobs/sleep
+    cwd: /path/to/working/directory
     on_finish: notify-send -a "zapusk" "Job Finished" "{job.name} has finished" --icon kitty
     on_fail: notify-send -a "zapusk" "Job Failed" "{job.name} has failed" --icon kitty
 ```
 
-### Waybar Integration
+## Waybar Integration
 
 Zapusk integrates with Waybar to display job statuses and notifications directly on your desktop.
 
@@ -230,10 +248,7 @@ Zapusk integrates with Waybar to display job statuses and notifications directly
 }
 ```
 
-## Contribution
-
-We welcome contributions! If you find a bug or have an idea for improvement, please open an issue or submit a pull request on our GitHub repository.
 
 ## License
 
-Zapusk is licensed under the MIT License. See the [LICENSE](LICENSE) file for more information.
+Zapusk is licensed under the MIT License. See the [LICENSE](LICENSE.md) file for more information.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,6 +14,7 @@ jobs:
   - name: Sleep 10 Seconds
     id: sleep_10
     command: sleep 10
+    cwd: /var/
 
   - name: Sleep 30 Seconds
     group: parallel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zapusk"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Anton Shuvalov <anton@shuvalov.info>"]
 readme = "README.md"

--- a/zapusk/client/__main__.py
+++ b/zapusk/client/__main__.py
@@ -1,3 +1,4 @@
+import os
 from type_docopt import docopt
 import importlib.metadata
 
@@ -95,6 +96,7 @@ def main():
             name=str(args["--name"]) if args["--name"] else None,
             schedule=str(args["--schedule"]) if args["--schedule"] else None,
             tail=bool(args["--tail"]),
+            cwd=os.getcwd(),
         )
         return
 

--- a/zapusk/client/api_client.py
+++ b/zapusk/client/api_client.py
@@ -27,6 +27,7 @@ class JobCreateFromConfigPayload(TypedDict):
 
 class JobCreateFromCommandPayload(TypedDict):
     command: str
+    cwd: str
     name: NotRequired[Optional[str]]
     group_id: NotRequired[Optional[str]]
 

--- a/zapusk/client/command.py
+++ b/zapusk/client/command.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
+from requests.exceptions import ConnectionError
 
 from .api_client import ApiClient, ApiClientError
 from .output import Output
@@ -28,3 +29,18 @@ class Command:
 
     def print_error(self, exception):
         self.output.error(exception, colors=self.colors)
+
+    def handle_error(self, ex):
+        if type(ex) ==ApiClientError:
+            self.print_error(ex)
+            return
+
+        if type(ex) == ConnectionError:
+            if "Connection refused by Responses" not in str(ex):
+                self.print_error(ApiClientError("Can not connect to the server. Please start server with `zapusk-server`"))
+                return
+
+        raise ex
+
+
+

--- a/zapusk/client/command_exec.py
+++ b/zapusk/client/command_exec.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 from zapusk.client.api_client import ApiClientError
@@ -9,6 +10,7 @@ class CommandExec(Command):
     def run(
         self,
         command: str,
+        cwd: str,
         name: Optional[str] = None,
         group_id: Optional[str] = None,
         schedule: Optional[str] = None,
@@ -23,6 +25,7 @@ class CommandExec(Command):
                         "group_id": group_id,
                         "name": name,
                         "schedule": schedule,
+                        "cwd": cwd,
                     }
                 )
 
@@ -35,6 +38,7 @@ class CommandExec(Command):
                     "command": command,
                     "group_id": group_id,
                     "name": name,
+                    "cwd": cwd,
                 }
             )
 
@@ -44,5 +48,5 @@ class CommandExec(Command):
 
             self.print_json(created_job)
 
-        except ApiClientError as ex:
-            self.print_error(ex)
+        except Exception as ex:
+            self.handle_error(ex)

--- a/zapusk/client/command_list.py
+++ b/zapusk/client/command_list.py
@@ -25,5 +25,5 @@ class CommandList(Command):
             self.print_json(jobs)
             return
 
-        except ApiClientError as ex:
-            self.print_error(ex)
+        except Exception as ex:
+            self.handle_error(ex)

--- a/zapusk/models/job.py
+++ b/zapusk/models/job.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+import os
 from typing import Optional
 
 from .id_field import IdField
@@ -64,6 +65,7 @@ class Job:
             name=config.name,
             on_finish=config.on_finish,
             on_fail=config.on_fail,
+            cwd=config.cwd,
         )
 
     group_config: JobGroup
@@ -84,6 +86,11 @@ class Job:
     group: str = "default"
     """
     job_group id
+    """
+
+    cwd: str = field(default_factory=lambda: os.environ["HOME"])
+    """
+    current working dir
     """
 
     job_config_id: Optional[str] = None

--- a/zapusk/models/job_config.py
+++ b/zapusk/models/job_config.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import os
 from typing import Optional
 
 from .base_model import BaseModel
@@ -19,6 +20,11 @@ class JobConfig(BaseModel):
     command: str
     """
     shell command for the job
+    """
+
+    cwd: str = field(default_factory=lambda: os.environ["HOME"])
+    """
+    current working dir
     """
 
     group: str = "default"

--- a/zapusk/server/controller_jobs.py
+++ b/zapusk/server/controller_jobs.py
@@ -1,3 +1,4 @@
+import os
 from flask import Blueprint, Response, abort, request
 from zapusk.lib.json_serdes import JsonSerdes
 from zapusk.models import Job, JobConfig, IdField
@@ -27,6 +28,7 @@ def create_jobs_api(config_service, executor_manager_service):
         body = request.json or {}
 
         job_config_id = body.get("job_config_id", None)
+        cwd = body.get("cwd", os.environ["HOME"])
 
         # if no config id, let's try to execute it as a command
         if not job_config_id:
@@ -59,6 +61,7 @@ def create_jobs_api(config_service, executor_manager_service):
                     id=cmd_id,
                     name=name or f"{job_group.id}.{cmd_id}",
                     command=command,
+                    cwd=cwd,
                 ),
             )
             executor_manager_service.add(job_item)

--- a/zapusk/server/controller_testcase.py
+++ b/zapusk/server/controller_testcase.py
@@ -1,0 +1,58 @@
+from unittest import TestCase
+from testfixtures import Replacer, TempDirectory
+
+from zapusk.services import (
+    ConfigService,
+    SchedulerService,
+    ExecutorManagerService,
+    ExecutorManagerKawkaBackend,
+)
+
+from .api import create_app
+
+
+class ControllerTestCase(TestCase):
+    maxDiff = None
+    config_data = ""
+
+    def before_create_services(self): ...
+
+    def setUp(self) -> None:
+        self.replace = Replacer()
+
+        self.temp_dir = TempDirectory()
+        self.config_file = self.temp_dir / "config.yml"
+        self.config_file.write_text(self.config_data)
+
+        self.before_create_services()
+
+        self.executor_manager_service = ExecutorManagerService(
+            backend=ExecutorManagerKawkaBackend(),
+        )
+        self.config_service = ConfigService(
+            config_path=f"{self.temp_dir.path}/config.yml"
+        )
+        self.scheduler_service = SchedulerService(
+            config_service=self.config_service,
+            executor_manager_service=self.executor_manager_service,
+        )
+        self.scheduler_service.start()
+
+        self.app = create_app(
+            executor_manager_service=self.executor_manager_service,
+            config_service=self.config_service,
+            scheduler_service=self.scheduler_service,
+        )
+        self.test_client = self.app.test_client()
+
+    def tearDown(self) -> None:
+        self.executor_manager_service.terminate()
+        self.scheduler_service.terminate()
+        self.temp_dir.cleanup()
+        self.replace.restore()
+
+    def write_config(self, data):
+        self.config_file.write_text(data)
+
+    def replace_in_environ(self, key, value):
+        self.replace.in_environ(key, value)

--- a/zapusk/services/config/config_parser_test.py
+++ b/zapusk/services/config/config_parser_test.py
@@ -1,4 +1,5 @@
 import pytest
+from testfixtures import Replacer
 import yaml
 
 from zapusk.services.config.constants import DEFAULT_COLORS
@@ -36,6 +37,7 @@ jobs:
                         "name": "Sleep Timer",
                         "id": "sleep",
                         "command": "sleep 10",
+                        "cwd": "/home/",
                         "group": "default",
                         "args_command": None,
                     }
@@ -70,6 +72,7 @@ jobs:
                         "name": "Sleep Timer",
                         "id": "sleep",
                         "command": "sleep 10",
+                        "cwd": "/home/",
                         "group": "awesome_group",
                         "args_command": None,
                     }
@@ -122,6 +125,7 @@ jobs:
                         "name": "Sleep Timer",
                         "id": "sleep",
                         "command": "sleep 10",
+                        "cwd": "/home/",
                         "group": "default",
                         "args_command": None,
                         "on_fail": "echo job_fail",
@@ -156,6 +160,7 @@ jobs:
                         "name": "Sleep Timer",
                         "id": "sleep",
                         "command": "sleep 10",
+                        "cwd": "/home/",
                         "group": "default",
                         "args_command": None,
                     }
@@ -173,11 +178,15 @@ jobs:
     ],
 )
 def test_config_parser_should_parse_config(config_yaml, expected_result):
+    replace = Replacer()
+    replace.in_environ("HOME", "/home/")
+
     config_parser = ConfigParser()
     config_data = yaml.safe_load(config_yaml)
     res = config_parser.parse(config_data)
 
     assert res == expected_result
+    replace.restore()
 
 
 ####################################

--- a/zapusk/services/config/service.py
+++ b/zapusk/services/config/service.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class ConfigService:
-    config_path: str
+    config_path: str | None
 
     def __init__(
         self,
@@ -29,7 +29,9 @@ class ConfigService:
         Returns a path to the config file considering evnironment configuration
         """
         if config_path:
-            return os.path.expanduser(config_path)
+            if isfile(config_path):
+                return os.path.expanduser(config_path)
+            return None
 
         config_dir = os.path.join(
             os.environ.get("APPDATA")
@@ -50,10 +52,13 @@ class ConfigService:
             logger.debug(f"Loaded config file: {config_dir}/config.yml")
             return f"{config_dir}/config.yml"
         else:
-            raise FileExistsError("Config not found")
+            return None
 
     def get_config(self):
-        config = self.file_reader.read(self.config_path)
+        if self.config_path:
+            config = self.file_reader.read(self.config_path)
+        else:
+            config = {}
         return self.parser.parse(config)
 
     def list_jobs(self):

--- a/zapusk/services/executor_manager/backends/kawka/args_consumer.py
+++ b/zapusk/services/executor_manager/backends/kawka/args_consumer.py
@@ -1,6 +1,8 @@
+import os
 import logging
 from datetime import datetime
 import subprocess
+
 
 from zapusk.kawka import Consumer
 from zapusk.models import Job
@@ -24,6 +26,8 @@ class ArgsConsumer(Consumer):
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env={**os.environ},
+            cwd=job.cwd,
         )
         exit_code = proc.wait()
         out, err = proc.communicate()

--- a/zapusk/services/executor_manager/backends/kawka/consumer_test.py
+++ b/zapusk/services/executor_manager/backends/kawka/consumer_test.py
@@ -1,3 +1,4 @@
+import os
 from time import sleep
 from unittest import TestCase, mock
 from testfixtures.mock import call
@@ -16,7 +17,11 @@ class ExecutorManagerTest(TestCase):
         self.Popen = MockPopen()
         self.r = Replacer()
         self.r.replace("subprocess.Popen", self.Popen)
+        self.r.in_environ("HOME", "/home/")
         self.addCleanup(self.r.restore)
+
+    def tearDown(self) -> None:
+        self.r.restore()
 
     def test_should_get_args_and_run_job(self):
         input_producer = Producer(name="input_producer")
@@ -45,6 +50,8 @@ class ExecutorManagerTest(TestCase):
             call.Popen(
                 "get_args",
                 shell=True,
+                env={**os.environ},
+                cwd="/home/",
                 stdout=-1,
                 stderr=-1,
             ),
@@ -54,6 +61,8 @@ class ExecutorManagerTest(TestCase):
             call.Popen(
                 "my_command hello world",
                 shell=True,
+                env={**os.environ},
+                cwd="/home/",
                 stdout=mock.ANY,
                 stderr=mock.ANY,
             ),

--- a/zapusk/services/executor_manager/backends/kawka/executor.py
+++ b/zapusk/services/executor_manager/backends/kawka/executor.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import subprocess
 from time import time
@@ -33,6 +34,8 @@ class Executor(Consumer):
                 shell=True,
                 stdout=logfile,
                 stderr=logfile,
+                env={**os.environ},
+                cwd=job.cwd,
             )
             job.pid = proc.pid
 
@@ -53,6 +56,8 @@ class Executor(Consumer):
                 subprocess.Popen(
                     on_finish.format(job=job),
                     shell=True,
+                    env={**os.environ},
+                    cwd=job.cwd,
                 )
 
         else:
@@ -64,6 +69,8 @@ class Executor(Consumer):
                 subprocess.Popen(
                     on_fail.format(job=job),
                     shell=True,
+                    env={**os.environ},
+                    cwd=job.cwd,
                 )
 
             logger.info(f"{self.name} failed {job} job")

--- a/zapusk/services/executor_manager/backends/kawka/executor_test.py
+++ b/zapusk/services/executor_manager/backends/kawka/executor_test.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase, mock
 from testfixtures.mock import call
 from testfixtures import Replacer
@@ -15,6 +16,7 @@ class ExecutorTest(TestCase):
         self.Popen = MockPopen()
         self.r = Replacer()
         self.r.replace("subprocess.Popen", self.Popen)
+        self.r.in_environ("HOME", "/home/")
         self.addCleanup(self.r.restore)
 
     def test_consumer_should_run_command(self):
@@ -34,6 +36,8 @@ class ExecutorTest(TestCase):
             call.Popen(
                 "echo 1",
                 shell=True,
+                env={**os.environ},
+                cwd="/home/",
                 stdout=mock.ANY,
                 stderr=mock.ANY,
             ),
@@ -60,6 +64,8 @@ class ExecutorTest(TestCase):
             call.Popen(
                 "echo 1",
                 shell=True,
+                env={**os.environ},
+                cwd="/home/",
                 stdout=mock.ANY,
                 stderr=mock.ANY,
             ),
@@ -69,6 +75,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[2],
             call.Popen(
                 "echo finish",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
             ),
         )
@@ -92,6 +100,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[0],
             call.Popen(
                 "echo 1",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
                 stdout=mock.ANY,
                 stderr=mock.ANY,
@@ -102,6 +112,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[2],
             call.Popen(
                 "echo finish",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
             ),
         )
@@ -132,6 +144,8 @@ class ExecutorTest(TestCase):
             call.Popen(
                 "echo 1",
                 shell=True,
+                env={**os.environ},
+                cwd="/home/",
                 stdout=mock.ANY,
                 stderr=mock.ANY,
             ),
@@ -141,6 +155,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[2],
             call.Popen(
                 "echo finish",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
             ),
         )
@@ -164,6 +180,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[0],
             call.Popen(
                 "exit 1",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
                 stdout=mock.ANY,
                 stderr=mock.ANY,
@@ -174,6 +192,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[2],
             call.Popen(
                 "echo fail",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
             ),
         )
@@ -197,6 +217,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[0],
             call.Popen(
                 "exit 1",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
                 stdout=mock.ANY,
                 stderr=mock.ANY,
@@ -207,6 +229,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[2],
             call.Popen(
                 "echo fail",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
             ),
         )
@@ -234,6 +258,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[0],
             call.Popen(
                 "exit 1",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
                 stdout=mock.ANY,
                 stderr=mock.ANY,
@@ -244,6 +270,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[2],
             call.Popen(
                 "echo fail",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
             ),
         )
@@ -264,6 +292,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[0],
             call.Popen(
                 "echo 1 2 3",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
                 stdout=mock.ANY,
                 stderr=mock.ANY,
@@ -287,6 +317,8 @@ class ExecutorTest(TestCase):
             self.Popen.all_calls[0],
             call.Popen(
                 "exit 1",
+                env={**os.environ},
+                cwd="/home/",
                 shell=True,
                 stdout=mock.ANY,
                 stderr=mock.ANY,

--- a/zapusk/services/scheduler_service/service_test.py
+++ b/zapusk/services/scheduler_service/service_test.py
@@ -24,6 +24,8 @@ class MockExecutorManager:
 
 
 class TestSchedulerService(TestCase):
+    maxDiff = None
+
     def setUp(self) -> None:
         self.temp_dir = TempDirectory()
         self.config_file = self.temp_dir / "config.yml"
@@ -38,6 +40,7 @@ class TestSchedulerService(TestCase):
         self.r = Replacer()
         self.r.replace("zapusk.services.scheduler_service.service.datetime", self.d)
         self.r.replace("zapusk.models.scheduled_job.datetime", self.d)
+        self.r.in_environ("HOME", self.temp_dir.path)
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
@@ -111,6 +114,7 @@ class TestSchedulerService(TestCase):
                     "id": "1",
                     "name": "1",
                     "command": "echo 1",
+                    "cwd": self.temp_dir.path,
                     "group": "default",
                     "args_command": None,
                     "on_finish": None,
@@ -121,6 +125,7 @@ class TestSchedulerService(TestCase):
                     "id": "2",
                     "name": "2",
                     "command": "echo 2",
+                    "cwd": self.temp_dir.path,
                     "group": "default",
                     "args_command": None,
                     "on_finish": None,
@@ -163,6 +168,7 @@ class TestSchedulerService(TestCase):
                     "id": "2",
                     "name": "2",
                     "command": "echo 2",
+                    "cwd": self.temp_dir.path,
                     "group": "default",
                     "args_command": None,
                     "on_finish": None,
@@ -207,6 +213,7 @@ class TestSchedulerService(TestCase):
                     "id": "1",
                     "name": "1",
                     "command": "echo 1",
+                    "cwd": self.temp_dir.path,
                     "group": "default",
                     "args_command": None,
                     "on_finish": None,
@@ -217,6 +224,7 @@ class TestSchedulerService(TestCase):
                     "id": "2",
                     "name": "2",
                     "command": "echo 2",
+                    "cwd": self.temp_dir.path,
                     "group": "default",
                     "args_command": None,
                     "on_finish": None,


### PR DESCRIPTION
It's interesting that this was missed. Now, the Job and JobConfig models support the cwd attribute. For pre-configured jobs, if cwd isn't defined in the configuration, it defaults to $HOME. For the zapusk exec command, cwd is the current working directory from which zapusk exec is run.